### PR TITLE
Added basic_auth() method

### DIFF
--- a/spec/unit/client_spec.cr
+++ b/spec/unit/client_spec.cr
@@ -1,7 +1,15 @@
 require "../spec_helper"
 
 describe Cossack::Client do
-  it "can be initialize" do
+  it "can be initialized" do
     Cossack::Client.new
+  end
+
+  it "has a basic_auth that works" do
+    client = Cossack::Client.new(TEST_SERVER_URL) do |client|
+      client.basic_auth("test", "secret")
+    end
+    client.headers["Authorization"].should_not be_nil
+    client.headers["Authorization"].should eq("Basic dGVzdDpzZWNyZXQ=")
   end
 end

--- a/src/cossack/client.cr
+++ b/src/cossack/client.cr
@@ -26,6 +26,14 @@ module Cossack
       initialize(base_url) { }
     end
 
+    # Equivalent to setting `headers["Authorization"]` to
+    # `"Basic #{Base64.strict_encode(username, password)}"`
+    def basic_auth(username : String, password : String)
+      username_password = "#{username}:#{password}"
+      encoded = Base64.strict_encode(username_password)
+      @headers["Authorization"] = "Basic #{encoded}"
+    end
+
     def use(middleware_class, *args, **nargs)
       @middlewares << middleware_class.new(@app, *args, **nargs)
       @app = @middlewares.last

--- a/src/cossack/connection/http_connection.cr
+++ b/src/cossack/connection/http_connection.cr
@@ -2,11 +2,22 @@ module Cossack
   # A connection to perform a real HTTP request using the standard library.
   class HTTPConnection < Connection
     def call(request : Request) : Response
-      client = HTTP::Client.new(request.uri)
+      uri = request.uri
+      scheme = uri.scheme
+      uri_host = uri.host
+      client = if uri_host.nil?
+        HTTP::Client.new(uri)
+      else
+        HTTP::Client.new(uri_host, uri.port, scheme == "https")
+      end
+
       client.connect_timeout = request.options.connect_timeout
       client.read_timeout = request.options.read_timeout
 
-      http_response = client.exec(request.method, request.uri.to_s, request.headers, request.body)
+      uri_string = uri.to_s
+      base_url = uri.port.nil? ? "#{scheme}://#{uri_host}" : "#{scheme}://#{uri_host}:#{uri.port}"
+      path = uri_string.starts_with?(base_url) ? uri_string[base_url.size, uri_string.size - base_url.size] : uri_string
+      http_response = client.exec(request.method, path, request.headers, request.body)
       Response.new(http_response.status_code, http_response.headers, http_response.body)
     rescue err : IO::Timeout
       raise TimeoutError.new(err.message, cause: err)


### PR DESCRIPTION
This is patterned after Faraday's own `basic_auth()` method.

##### Usage

```
    client = Cossack::Client.new(TEST_SERVER_URL) do |client|
      client.basic_auth("test", "secret")
    end
```

which is equivalent setting `headers["Authorization"]` to `"Basic #{Base64.strict_encode(username, password)}"`

##### Test

```
    client.headers["Authorization"].should_not be_nil
    client.headers["Authorization"].should eq("Basic dGVzdDpzZWNyZXQ=")
```

(This branch is built upon and also includes the fix for #16.)
