### PR TITLE
Updated Request body to accept String,  Bytes, IO or Nil

### DIFF
--- a/src/cossack.cr
+++ b/src/cossack.cr
@@ -5,6 +5,7 @@ require "./cossack/**"
 
 module Cossack
   alias Params = Hash(String, String)
+  alias BodyType = String | Bytes | IO | Nil
 
   # Common Cossack error.
   class Error < Exception; end

--- a/src/cossack/client.cr
+++ b/src/cossack/client.cr
@@ -5,7 +5,7 @@ module Cossack
     @base_uri : URI
     @headers : HTTP::Headers
     @cookies : CookieJar
-    @app : Middleware|Connection|Proc(Request, Response)
+    @app : Middleware | Connection | Proc(Request, Response)
 
     getter :base_uri, :headers, :request_options, :connection, :cookies
 
@@ -31,7 +31,7 @@ module Cossack
       @app = @middlewares.last
     end
 
-    def connection=(conn : Proc(Request, Response)|Connection)
+    def connection=(conn : Proc(Request, Response) | Connection)
       @connection = conn
       if @middlewares.first?
         @middlewares.first.__set_app__(@connection)
@@ -69,20 +69,18 @@ module Cossack
       end
     {% end %}
 
-
     {% for method in %w(post put patch) %}
-      def {{method.id}}(url : String, body : String = "")
+      def {{method.id}}(url : String, body : BodyType = "")
         {{method.id}}(url, body) { }
       end
 
-      def {{method.id}}(url : String, body : String = "")
+      def {{method.id}}(url : String, body : BodyType = "")
         uri = complete_uri!(URI.parse(url))
         request = Request.new("{{method.id.upcase}}", uri, @headers.dup, body, @request_options.dup)
         yield(request)
         call(request)
       end
     {% end %}
-
 
     private def default_headers
       HTTP::Headers.new.tap do |headers|

--- a/src/cossack/request.cr
+++ b/src/cossack/request.cr
@@ -2,26 +2,26 @@ module Cossack
   # Request built by Client, that can be processed by middleware and a connection.
   #
   # ```
-  # request.method  # => "POST"
-  # request.uri     # => #<URI:0x11b8ea0 @scheme="http", @host="example.org" ...>
-  # request.body    # => "payload"
-  # request.headers # => #<HTTP::Headers ... >
-  # request.options.connect_timeout  # => 30
-  # request.options.read_timeout     # => 30
+  # request.method                  # => "POST"
+  # request.uri                     # => #<URI:0x11b8ea0 @scheme="http", @host="example.org" ...>
+  # request.body                    # => "payload"
+  # request.headers                 # => #<HTTP::Headers ... >
+  # request.options.connect_timeout # => 30
+  # request.options.read_timeout    # => 30
   # ```
   class Request
     @method : String
     @uri : URI
     @headers : HTTP::Headers
-    @body : String?
+    @body : BodyType
     @options : RequestOptions
 
     property :method, :uri, :headers, :body, :options
 
-    def initialize(@method : String, @uri : URI, @headers : HTTP::Headers = HTTP::Headers.new, @body : String? = nil, @options = RequestOptions.new)
+    def initialize(@method : String, @uri : URI, @headers : HTTP::Headers = HTTP::Headers.new, @body : BodyType = nil, @options = RequestOptions.new)
     end
 
-    def initialize(@method : String, uri : String, @headers : HTTP::Headers = HTTP::Headers.new, @body : String? = nil, @options = RequestOptions.new)
+    def initialize(@method : String, uri : String, @headers : HTTP::Headers = HTTP::Headers.new, @body : BodyType = nil, @options = RequestOptions.new)
       @uri = URI.parse(uri)
     end
   end


### PR DESCRIPTION
Body with String type was more restrictive and for arbitrary large binary files, it required to read everything into String and then invoke Request method. Crystal `HTTP::Request` also accepts the same modified Body types.